### PR TITLE
feat: add gitpod environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Build & Push
+on:
+  pull_request:
+    branches:
+      - main
+      - rc*/*
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+-*" # Push events to matching v*, i.e. v20.15.10-rc5
+env:
+  registry: docker.io
+  repository: finschia/cw-gitpod
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: login to the registry
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ${{env.registry}}
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
+      - name: extract metadata for docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{env.registry}}/${{env.repository}}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: docker build
+        uses: docker/build-push-action@v5
+        with:
+          push: ${{github.event_name != 'pull_request'}}
+          tags: ${{steps.meta.outputs.tags}}
+          labels: ${{steps.meta.outputs.labels}}
+          platforms: linux/amd64
+          file: .gitpod.Dockerfile

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,16 @@
+FROM gitpod/workspace-full@sha256:bb84c4490170fbfdeb577535a6dec5aafd1eb8fdf433f9a344bd8f4a69af5707
+ARG FNSA_VERSION=2.0.1
+
+RUN rustup toolchain install 1.69.0
+RUN rustup default 1.69.0
+RUN rustup target add wasm32-unknown-unknown
+RUN rustup default 1.74.1
+RUN cargo install cosmwasm-check
+RUN cargo install cargo-generate
+RUN rustup default 1.69.0
+
+USER root
+RUN wget -O /usr/local/bin/fnsad https://github.com/Finschia/finschia/releases/download/v$FNSA_VERSION/fnsad-$FNSA_VERSION-linux-amd64
+RUN chmod 755 /usr/local/bin/fnsad
+
+USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,8 +5,8 @@ RUN rustup toolchain install 1.69.0
 RUN rustup default 1.69.0
 RUN rustup target add wasm32-unknown-unknown
 RUN rustup default 1.74.1
-RUN cargo install cosmwasm-check
-RUN cargo install cargo-generate
+RUN cargo install cosmwasm-check@1.5.0
+RUN cargo install cargo-generate@0.19.0
 RUN rustup default 1.69.0
 
 USER root

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,8 +25,7 @@ tasks:
 
     command: |
       ##
-      #
-
+      # run localnet and faucet
       cd ../tutorials/localnet/single
       docker-compose up -d finschia faucet
       cd ../../../cosmwasm

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,32 @@
+image: finschia/cw-gitpod:latest
+
+checkoutLocation: "cw-gitpod"
+workspaceLocation: "./cw-gitpod/cosmwasm"
+
+vscode:
+  extensions:
+    - rust-lang.rust-analyzer
+    - Spoorthi.cosmy-wasmy
+    - tamasfe.even-better-toml
+
+tasks:
+  - name: Setup
+
+    init: |
+      ##
+      # clone tutorials
+      cd ..
+      git clone https://github.com/Finschia/tutorials.git
+      cd cosmwasm
+
+      ##
+      # generate workspace.
+      cargo generate --git https://github.com/Finschia/cw-workspace.git --name tutorial --init -o
+
+    command: |
+      ##
+      #
+
+      cd ../tutorials/localnet/single
+      docker-compose up -d finschia faucet
+      cd ../../../cosmwasm

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# cw-gitpod
+# CW Gitpod
+
+This is an environment for developing Finschia CosmWasm contracts on [Gitpod](https://www.gitpod.io/).
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Finschia/cw-gitpod)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 This is an environment for developing Finschia CosmWasm contracts on [Gitpod](https://www.gitpod.io/).
 
+This provides the following environment:
+
+- Install rustc, cargo, cargo-check, cargo-generate, and fnsad in advance
+- Run Finschia localnet and the faucet server in advance
+- Install rust-analyzer, cosmy-wasmy, and even-better-toml for vscode in advance
+
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Finschia/cw-gitpod)


### PR DESCRIPTION
This PR adds gitpod environment for Finschia CosmWasm. You can't try this because a docker image isn't pushed to hub yet.

This provides the following environment:

- Install rustc, cargo, cargo-check, cargo-generate, and fnsad in advance
- Run Finschia localnet and the faucet server in advance
- Install rust-analyzer, cosmy-wasmy, and even-better-toml in advance
