### PR TITLE
fix: clear gitpod initialization log

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,3 +29,7 @@ tasks:
       cd ../tutorials/localnet/single
       docker-compose up -d finschia faucet
       cd ../../../cosmwasm
+
+      ##
+      # clear
+      clear


### PR DESCRIPTION
This PR enable to clear gitpod initialization log.